### PR TITLE
Use motif file name to annotate motifs. Important for Metaclusters.

### DIFF
--- a/src/tfmindi/datasets.py
+++ b/src/tfmindi/datasets.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import zipfile
 from pathlib import Path
 
@@ -141,7 +142,7 @@ def fetch_motif_annotations(species: str = "hgnc", version: str = "v10nr_clust")
     return annotations_file
 
 
-def load_motif(file_name: str) -> dict[str, np.ndarray]:
+def load_motif(file_name: str) -> dict[tuple[str, str], np.ndarray]:
     """
     Load motif(s) from a single .cb file.
 
@@ -154,45 +155,47 @@ def load_motif(file_name: str) -> dict[str, np.ndarray]:
 
     Returns
     -------
-    dict[str, np.ndarray]
-        Dictionary mapping motif names to PWM matrices (4 x length)
+    dict[tuple[str, str], np.ndarray]
+        Dictionary mapping motif file names and names to PWM matrices (4 x length)
 
     Examples
     --------
     >>> motifs = load_motif("./motif1.cb")
     >>> print(list(motifs.keys()))
-    ['motif1', 'motif2']
-    >>> print(motifs["motif1"].shape)
+    [("filename_1", "motif_1"), ("filename_2", "motif_2")]
+    >>> print(motifs[("filename_1", "motif_1")].shape)
     (4, 12)
     """
-    motifs: dict[str, np.ndarray] = {}
+    motifs: dict[tuple[str, str], np.ndarray] = {}
     with open(file_name) as f:
         name = f.readline().strip()
         if not name.startswith(">"):
             raise ValueError(f"First line of {file_name} does not start with '>'.")
         name = name.replace(">", "")
-        pwm = []
+        key = (os.path.basename(file_name).replace(".cb", ""), name)
+        pwm: list[list[float]] = []
         for line in f:
             line = line.strip()
             if line.startswith(">"):
                 # we are at the start of a new motif
-                motifs[name] = np.array(pwm)
+                motifs[key] = np.array(pwm)
                 # scale values of motif
-                motifs[name] = motifs[name].T / motifs[name].sum(1)
+                motifs[key] = motifs[key].T / motifs[key].sum(1)
                 # reset pwm and read new name
                 name = line.replace(">", "")
+                key = (os.path.basename(file_name).replace(".cb", ""), name)
                 pwm = []
             else:
                 # we are in the middle of reading the pwm values
                 pwm.append([float(v) for v in line.split()])
         # add last motif
-        motifs[name] = np.array(pwm)
+        motifs[key] = np.array(pwm)
         # scale values of motif
-        motifs[name] = motifs[name].T / motifs[name].sum(1)
+        motifs[key] = motifs[key].T / motifs[key].sum(1)
     return motifs
 
 
-def load_motif_collection(motif_dir: str, motif_names: list[str] | None = None) -> dict[str, np.ndarray]:
+def load_motif_collection(motif_dir: str, motif_names: list[str] | None = None) -> dict[tuple[str, str], np.ndarray]:
     """
     Load motif collection from directory of .cb files.
 
@@ -207,15 +210,15 @@ def load_motif_collection(motif_dir: str, motif_names: list[str] | None = None) 
 
     Returns
     -------
-    dict[str, np.ndarray]
+    dict[tuple[str, str], np.ndarray]
         Dictionary mapping motif names to PWM matrices (4 x length)
 
     Examples
     --------
     >>> motifs = load_motif_collection("./motif_collection/")
-    >>> print(list(motifs.keys())[:3])
-    ['motif1', 'motif2', 'motif3']
-    >>> print(motifs["motif1"].shape)
+    >>> print(list(motifs.keys()))
+    [("filename_1", "motif_1"), ("filename_1", "motif_2"), ("filename_1", "motif_4")]
+    >>> print(motifs[("filename_1", "motif_1")].shape)
     (4, 12)
 
     >>> # Load only specific motifs
@@ -228,7 +231,7 @@ def load_motif_collection(motif_dir: str, motif_names: list[str] | None = None) 
     if not motif_dir_path.exists():
         raise FileNotFoundError(f"Directory {motif_dir_path} does not exist")
 
-    motifs = {}
+    motifs: dict[tuple[str, str], np.ndarray] = {}
 
     cb_files = list(motif_dir_path.glob("*.cb"))
 
@@ -244,7 +247,7 @@ def load_motif_collection(motif_dir: str, motif_names: list[str] | None = None) 
     # Filter motifs if specific names are provided
     if motif_names is not None:
         motif_names_set = set(motif_names)
-        motifs = {name: pwm for name, pwm in motifs.items() if name in motif_names_set}
+        motifs = {(filename, name): pwm for (filename, name), pwm in motifs.items() if name in motif_names_set}
 
     return motifs
 

--- a/src/tfmindi/pp/seqlets.py
+++ b/src/tfmindi/pp/seqlets.py
@@ -127,7 +127,7 @@ def extract_seqlets(
 
 def calculate_motif_similarity(
     seqlets: list[np.ndarray],
-    known_motifs: list[np.ndarray] | dict[str, np.ndarray],
+    known_motifs: list[np.ndarray] | dict[tuple[str, str], np.ndarray],
     chunk_size: int | None = None,
     n_nearest: int | None = None,
     threshold: float | None = None,
@@ -278,8 +278,8 @@ def create_seqlet_adata(
     seqlet_matrices: list[np.ndarray[Any, np.dtype[np.floating]]] | None = None,
     oh_sequences: np.ndarray[Any, np.dtype[np.floating]] | None = None,
     contrib_scores: np.ndarray[Any, np.dtype[np.floating]] | None = None,
-    motif_names: list[str] | None = None,
-    motif_collection: dict[str, np.ndarray[Any, np.dtype[np.floating]]]
+    motif_names: list[str] | list[tuple[str, str]] | None = None,
+    motif_collection: dict[tuple[str, str], np.ndarray[Any, np.dtype[np.floating]]]
     | list[np.ndarray[Any, np.dtype[np.floating]]]
     | None = None,
     motif_annotations: pd.DataFrame | None = None,
@@ -376,7 +376,7 @@ def create_seqlet_adata(
                 f"Number of motif names ({len(motif_names)}) "
                 f"does not match number of motifs in similarity matrix ({n_motifs})"
             )
-        var_df = pd.DataFrame(index=motif_names)
+        var_df = pd.DataFrame(index=[fn_name[1] if isinstance(fn_name, tuple) else fn_name for fn_name in motif_names])
     else:
         var_df = pd.DataFrame(index=[f"motif_{i}" for i in range(n_motifs)])
 
@@ -386,7 +386,9 @@ def create_seqlet_adata(
             motif_ppms = list(motif_collection.values())
             if motif_names is None:
                 motif_names = list(motif_collection.keys())
-                var_df = pd.DataFrame(index=motif_names)
+                var_df = pd.DataFrame(
+                    index=[fn_name[1] if isinstance(fn_name, tuple) else fn_name for fn_name in motif_names]
+                )
         else:
             motif_ppms = motif_collection
 
@@ -403,20 +405,24 @@ def create_seqlet_adata(
     # Store motif annotations in .var if provided
     if motif_annotations is not None and motif_names is not None:
         # Add annotations for motifs that are present in the similarity matrix
-        for motif_name in motif_names:
-            if motif_name in motif_annotations.index:
+        for fn_name in motif_names:
+            file_name = fn_name[0] if isinstance(fn_name, tuple) else fn_name
+            name = fn_name[1] if isinstance(fn_name, tuple) else fn_name
+            if file_name in motif_annotations.index:
                 # Add all annotation columns for this motif
                 for col in motif_annotations.columns:
                     if col not in var_df.columns:
                         var_df[col] = None  # Initialize column
-                    var_df.loc[motif_name, col] = motif_annotations.loc[motif_name, col]
+                    var_df.loc[name, col] = motif_annotations.loc[file_name, col]
 
     # Store DNA-binding domain annotations if provided
     if motif_to_dbd is not None and motif_names is not None:
         var_df["dbd"] = None  # Initialize column
-        for motif_name in motif_names:
-            if motif_name in motif_to_dbd:
-                var_df.loc[motif_name, "dbd"] = motif_to_dbd[motif_name]
+        for fn_name in motif_names:
+            file_name = fn_name[0] if isinstance(fn_name, tuple) else fn_name
+            name = fn_name[1] if isinstance(fn_name, tuple) else fn_name
+            if file_name in motif_to_dbd:
+                var_df.loc[name, "dbd"] = motif_to_dbd[file_name]
 
     # Convert sparse array data to specified dtype for memory optimization
     if hasattr(similarity_matrix, "astype"):


### PR DESCRIPTION
I realised I made a mistake in how the motifs are annotated.

In the motif collection we have two types of motifs:
1.  single motifs
2. metaclusters

metacluster files look like this

```bash

$ cat metacluster

> motif_1
<data>
> motif_2
<data>
> motif_3
<data>

```

The motif-to-tf annotation database only has annotations on the metacluster level (i.e. motif_1, motif_2, motif_3) will not have annotations.

Before the annotation in TF-MinDI were __not __ based on the metacluster and therefore many motifs did not have an annotation, while they actually should have one.

Now

```python

def load_motif(file_name: str)

```

returns a tuple of `(filename, motif_name)` the filename refer to the metaclusters.

https://github.com/aertslab/TF-MInDi/blob/aa57fed4e628cb153e66b3ae4a9b0b22762cf83c/src/tfmindi/datasets.py#L145

I also changed downstream functions to be compatible with this change.

