### PR TITLE
add option to filter on min_seqlets in logo plotting (default = 10)

### DIFF
--- a/docs/notebooks/02_analysis_tutorial.ipynb
+++ b/docs/notebooks/02_analysis_tutorial.ipynb
@@ -366,7 +366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "154ad6e2",
    "metadata": {},
    "outputs": [
@@ -394,6 +394,7 @@
     "    logo_height=0.4,\n",
     "    logo_width=0.6,\n",
     "    ic_threshold=0.2,  # nucleotides in pattern below this will be trimmed\n",
+    "    min_seqlets=10,  # ignore patterns with less than this many seqlets in the cluster\n",
     ")"
    ]
   },

--- a/src/tfmindi/pl/tsne.py
+++ b/src/tfmindi/pl/tsne.py
@@ -114,6 +114,7 @@ def tsne_logos(
     s: float = 2,
     ic_threshold: float = 0.2,
     min_nucleotides: int = 4,
+    min_seqlets: int = 10,
     show_cluster_labels: bool = True,
     show_legend: bool = True,
     gray_background: bool = True,
@@ -151,6 +152,9 @@ def tsne_logos(
     min_nucleotides
         Minimum number of nucleotides required after trimming to show logo.
         Patterns with fewer nucleotides will be skipped to avoid showing noisy logos.
+    min_seqlets
+        Minimum number of seqlets required in a cluster to display its logo.
+        Clusters with fewer seqlets will be skipped to avoid showing weak motifs from small clusters.
     show_cluster_labels
         Whether to show cluster ID labels.
     show_legend
@@ -212,6 +216,12 @@ def tsne_logos(
     for cluster_id in adata.obs["leiden"].unique():
         if cluster_id in patterns:
             cluster_mask = adata.obs["leiden"] == cluster_id
+            cluster_size = cluster_mask.sum()
+
+            # Skip clusters with too few seqlets
+            if cluster_size < min_seqlets:
+                continue
+
             cluster_x = x_coords[cluster_mask].mean()
             cluster_y = y_coords[cluster_mask].mean()
             cluster_coords[cluster_id] = (cluster_x, cluster_y)


### PR DESCRIPTION
Usefull for very small clusters when you don't want to change your clustering resolution to not mess up other clusters