### PR TITLE
fix/rapids-single-cell_dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ scripts.clean = "git clean -fdX -- {args:docs}"
 # Test the lowest and highest supported Python versions with normal deps
 [[tool.hatch.envs.hatch-test.matrix]]
 deps = [ "stable" ]
-python = [ "3.10", "3.12" ]
+python = [ "3.12" ]
 
 [tool.hatch.envs.hatch-test]
 features = [ "test" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,9 @@ maintainers = [
 ]
 authors = [ { name = "Seppe De Winter" } ]
 # itaxotools-mafftpy requires python>=3.10.2
-requires-python = ">=3.10.2,<3.13"
+requires-python = ">=3.12,<3.13"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
@@ -59,11 +57,7 @@ optional-dependencies.doc = [
   "sphinxext-opengraph",
 ]
 optional-dependencies.gpu = [
-  "cudf-cu12==26.4.*",
-  "cugraph-cu12==26.4.*",
-  "cuml-cu12==26.4.*",
-  "cupy-cuda12x",
-  "rapids-singlecell<0.15",
+  "rapids-singlecell-cu12[rapids]",
 ]
 optional-dependencies.test = [ "coverage", "pytest" ]
 # https://docs.pypi.org/project_metadata/#project-urls


### PR DESCRIPTION
Fixes rapids-single-cell depency (it was not installing for me locally).


Also had to bump minimal Python version to 3.12 (I guess this is fine?).
Or do we want to maintain compatibility with lower version?

