### PR TITLE
Parallelize part of recursive_seqlets

### DIFF
--- a/src/tfmindi/pp/seqlets.py
+++ b/src/tfmindi/pp/seqlets.py
@@ -253,7 +253,7 @@ class recursive_raw(_1DSeqletCaller):  # noqa: D101
             min_seqlet_len=min_seqlet_len,
             max_seqlet_len=max_seqlet_len,
             additional_flanks=additional_flanks,
-            n_bins=10000,
+            n_bins=n_bins,
             n_jobs=n_jobs,
         )
         if raw is None or len(raw) == 0:

--- a/src/tfmindi/pp/seqlets.py
+++ b/src/tfmindi/pp/seqlets.py
@@ -203,6 +203,7 @@ class rec_q99_smooth_abs(_1DSeqletCaller):  # noqa: D101
         min_seqlet_len: int = 4,
         max_seqlet_len: int = 25,
         additional_flanks: int = 3,
+        n_bins: int = 10000,
         n_jobs: int = -1,
     ) -> pd.DataFrame:
         """Core backbone: triangular smooth -> q99 normalise -> recursive abs caller."""
@@ -216,6 +217,7 @@ class rec_q99_smooth_abs(_1DSeqletCaller):  # noqa: D101
             min_seqlet_len=min_seqlet_len,
             max_seqlet_len=max_seqlet_len,
             additional_flanks=additional_flanks,
+            n_bins=n_bins,
             n_jobs=n_jobs,
         )
         if len(raw) == 0:
@@ -234,6 +236,7 @@ class recursive_raw(_1DSeqletCaller):  # noqa: D101
         min_seqlet_len: int = 4,
         max_seqlet_len: int = 25,
         additional_flanks: int = 3,
+        n_bins: int = 10000,
         n_jobs: int = -1,
     ) -> pd.DataFrame:
         """Baseline caller: recursive seqlets on the raw *signed* 1D track.
@@ -250,6 +253,7 @@ class recursive_raw(_1DSeqletCaller):  # noqa: D101
             min_seqlet_len=min_seqlet_len,
             max_seqlet_len=max_seqlet_len,
             additional_flanks=additional_flanks,
+            n_bins=10000,
             n_jobs=n_jobs,
         )
         if raw is None or len(raw) == 0:
@@ -1636,7 +1640,7 @@ def create_seqlet_adata(
 
 
 def recursive_seqlets(
-    X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, additional_flanks=0, n_bins=1000, n_jobs=-1
+    X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, additional_flanks=0, n_bins=10000, n_jobs=-1
 ):
     """Call seqlets using the recursive seqlet algorithm.
 
@@ -1663,8 +1667,8 @@ def recursive_seqlets(
     (in addition to X) must also have a p-value below the threshold.
 
 
-                                                    min_seqlet_len
-                                --------
+                  min_seqlet_len
+                  --------
     . . . . . . . | . . . . / . . . . . . . .
     . . . . . . . | . . . / . . . . . . . . .
     . . . . . . . | . . / . . . . . . . . . .
@@ -1773,7 +1777,7 @@ def recursive_seqlets(
 # cache=True writes the compiled kernel to __pycache__, so only the first run of a fresh
 # install pays the ~2s JIT compile instead of every process.
 @numba.njit(cache=True)
-def _recursive_seqlets_distribution(X, max_seqlet_len=25, n_bins=1000):
+def _recursive_seqlets_distribution(X, max_seqlet_len, n_bins):
     """Build the shared null-distribution model.
 
     This is steps 1-2 of the recursive seqlet algorithm: bin attributions into a

--- a/src/tfmindi/pp/seqlets.py
+++ b/src/tfmindi/pp/seqlets.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from functools import partial
 from typing import Any, Literal, cast, get_args
@@ -202,6 +203,7 @@ class rec_q99_smooth_abs(_1DSeqletCaller):  # noqa: D101
         min_seqlet_len: int = 4,
         max_seqlet_len: int = 25,
         additional_flanks: int = 3,
+        n_jobs: int = -1,
     ) -> pd.DataFrame:
         """Core backbone: triangular smooth -> q99 normalise -> recursive abs caller."""
         X = _ensure_2d(X)
@@ -214,6 +216,7 @@ class rec_q99_smooth_abs(_1DSeqletCaller):  # noqa: D101
             min_seqlet_len=min_seqlet_len,
             max_seqlet_len=max_seqlet_len,
             additional_flanks=additional_flanks,
+            n_jobs=n_jobs,
         )
         if len(raw) == 0:
             return _seqlet_df([])
@@ -231,6 +234,7 @@ class recursive_raw(_1DSeqletCaller):  # noqa: D101
         min_seqlet_len: int = 4,
         max_seqlet_len: int = 25,
         additional_flanks: int = 3,
+        n_jobs: int = -1,
     ) -> pd.DataFrame:
         """Baseline caller: recursive seqlets on the raw *signed* 1D track.
 
@@ -246,6 +250,7 @@ class recursive_raw(_1DSeqletCaller):  # noqa: D101
             min_seqlet_len=min_seqlet_len,
             max_seqlet_len=max_seqlet_len,
             additional_flanks=additional_flanks,
+            n_jobs=n_jobs,
         )
         if raw is None or len(raw) == 0:
             return _seqlet_df([])
@@ -1170,7 +1175,9 @@ def extract_seqlets(
     """
     assert contrib.shape == oh.shape, "Contribution and one-hot arrays must have the same shape"
     if oh.shape[-2] > oh.shape[-1]:
-        raise ValueError(f"Please check that your values are in shape (n_examples, 4, length), not (n_examples, length, 4). Shape: {oh.shape}")
+        raise ValueError(
+            f"Please check that your values are in shape (n_examples, 4, length), not (n_examples, length, 4). Shape: {oh.shape}"
+        )
     caller = _lookup_seqlet_caller(method)
     bound = partial(caller, **method_kwargs)
     if isinstance(caller, _FitContribSeqletCaller):
@@ -1628,11 +1635,13 @@ def create_seqlet_adata(
     return adata
 
 
-def recursive_seqlets(X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, additional_flanks=0, n_bins=1000):
+def recursive_seqlets(
+    X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, additional_flanks=0, n_bins=1000, n_jobs=-1
+):
     """Call seqlets using the recursive seqlet algorithm.
 
-    THIS FUNCTION IS A DIRECT COPY FROM THE TANGERMEME REPOSITORY FROM JACOB SCHREIBER.
-    We do a direct copy here since we only need this function and we want to avoid the heavy torch installation.
+    THIS FUNCTION IS A REWRITTEN COPY FROM THE TANGERMEME REPOSITORY FROM JACOB SCHREIBER.
+    We do a copy here since we only need this function and we want to avoid the heavy torch installation.
 
     This algorithm identifies spans of high attribution characters, called
     seqlets, using a simple approach derived from the Tomtom/FIMO algorithms.
@@ -1703,6 +1712,9 @@ def recursive_seqlets(X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, ad
     n_bins: int, optional
         The number of bins to use when estimating the PDFs and CDFs. Default is
         1000.
+    n_jobs: int, optional
+        Number of threads to decode seqlets (step 4) with. -1 (default) uses
+        ``numba.get_num_threads()``.
 
 
     Returns
@@ -1713,8 +1725,41 @@ def recursive_seqlets(X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, ad
             of the (location, length) span and is not influenced by the other
             values within the triangle.
     """
+    n = X.shape[0]
+    X_csum, rcdfs, xmin, bin_width = _recursive_seqlets_distribution(
+        X, threshold, min_seqlet_len, max_seqlet_len, n_bins
+    )
+
+    resolved_n_jobs = numba.get_num_threads() if n_jobs == -1 else n_jobs
+    n_chunks = max(1, min(resolved_n_jobs, n))
+
+    if n_chunks == 1:
+        return _recursive_seqlets_decode(
+            X_csum, rcdfs, xmin, bin_width, threshold, min_seqlet_len, max_seqlet_len, additional_flanks, 0
+        )
+
+    boundaries = np.linspace(0, n, n_chunks + 1).astype(np.int64)
+    seqlets = []
+    with ThreadPoolExecutor(max_workers=n_chunks) as pool:
+        futures = [
+            pool.submit(
+                _recursive_seqlets_decode,
+                X_csum[boundaries[c] : boundaries[c + 1]],
+                rcdfs,
+                xmin,
+                bin_width,
+                threshold,
+                min_seqlet_len,
+                max_seqlet_len,
+                additional_flanks,
+                int(boundaries[c]),
+            )
+            for c in range(n_chunks)
+        ]
+        for future in futures:
+            seqlets.extend(future.result())
+
     columns = ["example_idx", "start", "end", "attribution", "p-value"]
-    seqlets = _recursive_seqlets(X, threshold, min_seqlet_len, max_seqlet_len, additional_flanks, n_bins)
     seqlets = pd.DataFrame(seqlets, columns=columns)
     return seqlets.sort_values("p-value").reset_index(drop=True)
 
@@ -1722,15 +1767,18 @@ def recursive_seqlets(X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, ad
 # cache=True writes the compiled kernel to __pycache__, so only the first run of a fresh
 # install pays the ~2s JIT compile instead of every process.
 @numba.njit(cache=True)
-def _recursive_seqlets(X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, additional_flanks=0, n_bins=1000):
-    """Call seqlets recursively using the Tangermeme algorithm.
+def _recursive_seqlets_distribution(X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, n_bins=1000):
+    """Build the shared null-distribution model and per-example cumulative sums.
 
-    This algorithm has four steps.
+    This is steps 1-3 of the recursive seqlet algorithm: bin attributions into a
+    histogram, derive per-length null distributions (1-CDFs), and compute each
+    example's cumulative attribution sum. These steps continually increment one
+    shared array and are not parallelized; step 4 (`_recursive_seqlets_decode`)
+    consumes their read-only output independently per example.
 
     (1) Convert attribution scores into integer bins and calculate a histogram
     (2) Convert these histograms into null distributions across lengths
-    (3) Use the null distributions to calculate p-values for each possible length
-    (4) Decode this matrix of p-values to find the longest seqlets
+    (3) Calculate each example's cumulative attribution sum
     """
     n, l = X.shape
     m = n * l
@@ -1770,7 +1818,7 @@ def _recursive_seqlets(X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, a
             rcdfs[seqlet_len, i] = max(rcdfs[seqlet_len, i - 1] - scores[seqlet_len, i], 0)
 
     ###
-    # Step 3: Calculate p-values given these 1-CDFs
+    # Step 3: Calculate cumulative attribution sums
     ###
 
     X_csum = np.zeros((n, l + 1))
@@ -1778,9 +1826,25 @@ def _recursive_seqlets(X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, a
         for j in range(l):
             X_csum[i, j + 1] = X_csum[i, j] + X[i, j]
 
-    ###
-    # Step 4: Decode p-values into seqlets
-    ###
+    return X_csum, rcdfs, xmin, bin_width
+
+
+@numba.njit(cache=True, nogil=True)
+def _recursive_seqlets_decode(
+    X_csum, rcdfs, xmin, bin_width, threshold, min_seqlet_len, max_seqlet_len, additional_flanks, row_offset
+):
+    """Decode seqlets for one contiguous block of examples (step 4).
+
+    `X_csum` holds only the rows for this block; `row_offset` is added back so
+    `example_idx` in the returned tuples matches the caller's global row index.
+    Independent per example, so this is safe to call concurrently from multiple
+    threads over disjoint row ranges of the same `X_csum`/`rcdfs` -- both are
+    read-only from this point on. Compiled with `nogil=True` so a
+    ThreadPoolExecutor calling this from several threads gets real multi-core
+    execution instead of contending for the GIL.
+    """
+    n, lp1 = X_csum.shape
+    l = lp1 - 1
 
     seqlets = []
 
@@ -1820,6 +1884,6 @@ def _recursive_seqlets(X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, a
                     end = min(start + seqlet_len + additional_flanks, l - 1)
                     start = max(start - additional_flanks, 0)
                     attr = X_csum[i, end] - X_csum[i, start]
-                    seqlets.append((i, start, end, attr, p))
+                    seqlets.append((i + row_offset, start, end, attr, p))
 
     return seqlets

--- a/src/tfmindi/pp/seqlets.py
+++ b/src/tfmindi/pp/seqlets.py
@@ -203,7 +203,7 @@ class rec_q99_smooth_abs(_1DSeqletCaller):  # noqa: D101
         min_seqlet_len: int = 4,
         max_seqlet_len: int = 25,
         additional_flanks: int = 3,
-        n_bins: int = 10000,
+        n_bins: int = 1000,
         n_jobs: int = -1,
     ) -> pd.DataFrame:
         """Core backbone: triangular smooth -> q99 normalise -> recursive abs caller."""
@@ -236,7 +236,7 @@ class recursive_raw(_1DSeqletCaller):  # noqa: D101
         min_seqlet_len: int = 4,
         max_seqlet_len: int = 25,
         additional_flanks: int = 3,
-        n_bins: int = 10000,
+        n_bins: int = 1000,
         n_jobs: int = -1,
     ) -> pd.DataFrame:
         """Baseline caller: recursive seqlets on the raw *signed* 1D track.
@@ -1132,15 +1132,16 @@ def extract_seqlets(
 
         - ``"recursive_q99_abs_smooth"`` (default): triangular-smooth, per-example
           q99 normalisation, then the recursive caller on ``abs(track)``.
-          Accepts ``smooth_window``, ``threshold`` (0.05), ``min_seqlet_len``,
-          ``max_seqlet_len``, ``additional_flanks`` (3).
+          Accepts ``smooth_window`` (9), ``threshold`` (0.05), ``min_seqlet_len`` (4),
+          ``max_seqlet_len`` (25), ``additional_flanks`` (3), ``n_bins`` (1000).
+          If not calling any seqlets with very large datasets, consider increasing ``n_bins``.
         - ``"recursive_raw"``: recursive caller on the raw signed track
           (reproduces the previous TF-MInDi default behaviour). Same knobs as above.
         - ``"hysteresis"``: two-threshold local caller. Accepts ``smooth_window``,
-          ``seed_z`` (2.5), ``grow_z`` (1.0), ``min_seqlet_len``, ``max_seqlet_len``,
-          ``merge_gap``.
+          ``seed_z`` (2.5), ``grow_z`` (1.0), ``min_seqlet_len`` (4), ``max_seqlet_len`` (25),
+          ``merge_gap`` (2).
         - ``"local_contrast"``: multi-scale sliding-window contrast caller. Accepts
-          ``windows``, ``smooth_window``, ``seed_z`` (4.0), ``expand_z``, ...
+          ``windows`` (10, 16, 24), ``smooth_window`` (9), ``seed_z`` (4.0), ``expand_z`` (1.25), ...
         - ``"wavelet_otsu"``: wavelet-denoise + Otsu-threshold caller (needs
           PyWavelets). Accepts ``wavelet``, ``threshold_scale`` (1.7),
           ``otsu_weight``, ``min_seqlet_len``, ...
@@ -1640,7 +1641,7 @@ def create_seqlet_adata(
 
 
 def recursive_seqlets(
-    X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, additional_flanks=0, n_bins=10000, n_jobs=-1
+    X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, additional_flanks=0, n_bins=1000, n_jobs=-1
 ):
     """Call seqlets using the recursive seqlet algorithm.
 
@@ -1650,8 +1651,7 @@ def recursive_seqlets(
     This algorithm identifies spans of high attribution characters, called
     seqlets, using a simple approach derived from the Tomtom/FIMO algorithms.
     First, distributions of attribution sums are created for all potential
-    seqlet lengths by discretizing the sum, with one set of distributions for
-    positive attribution values and one for negative attribution values. Then,
+    seqlet lengths by discretizing the sum. Then,
     CDFs are calculated for each distribution (or, more specifically, 1-CDFs).
     Finally, p-values are calculated via lookup to these 1-CDFs for all
     potential CDFs, yielding a (n_positions, n_lengths) matrix of p-values.
@@ -1715,9 +1715,9 @@ def recursive_seqlets(
             of all called seqlets. Does not affect the called seqlets.
     n_bins: int, optional
         The number of bins to use when estimating the PDFs and CDFs. Default is
-        1000.
+        1000. Recommended to increase 5x or 10x when using large datasets.
     n_jobs: int, optional
-        Number of threads to decode seqlets (step 4) with. -1 (default) uses
+        Number of threads to decode seqlets (steps 3 and 4) with. -1 (default) uses
         ``numba.get_num_threads()``.
 
 

--- a/src/tfmindi/pp/seqlets.py
+++ b/src/tfmindi/pp/seqlets.py
@@ -1726,38 +1726,44 @@ def recursive_seqlets(
             values within the triangle.
     """
     n = X.shape[0]
-    X_csum, rcdfs, xmin, bin_width = _recursive_seqlets_distribution(
-        X, threshold, min_seqlet_len, max_seqlet_len, n_bins
-    )
+    rcdfs, global_xmin, bin_width = _recursive_seqlets_distribution(X=X, max_seqlet_len=max_seqlet_len, n_bins=n_bins)
 
     resolved_n_jobs = numba.get_num_threads() if n_jobs == -1 else n_jobs
     n_chunks = max(1, min(resolved_n_jobs, n))
 
     if n_chunks == 1:
-        return _recursive_seqlets_decode(
-            X_csum, rcdfs, xmin, bin_width, threshold, min_seqlet_len, max_seqlet_len, additional_flanks, 0
+        seqlets = _recursive_seqlets_decode(
+            X=X,
+            rcdfs=rcdfs,
+            global_xmin=global_xmin,
+            bin_width=bin_width,
+            threshold=threshold,
+            min_seqlet_len=min_seqlet_len,
+            max_seqlet_len=max_seqlet_len,
+            additional_flanks=additional_flanks,
+            row_offset=0,
         )
-
-    boundaries = np.linspace(0, n, n_chunks + 1).astype(np.int64)
-    seqlets = []
-    with ThreadPoolExecutor(max_workers=n_chunks) as pool:
-        futures = [
-            pool.submit(
-                _recursive_seqlets_decode,
-                X_csum[boundaries[c] : boundaries[c + 1]],
-                rcdfs,
-                xmin,
-                bin_width,
-                threshold,
-                min_seqlet_len,
-                max_seqlet_len,
-                additional_flanks,
-                int(boundaries[c]),
-            )
-            for c in range(n_chunks)
-        ]
-        for future in futures:
-            seqlets.extend(future.result())
+    else:
+        boundaries = np.linspace(0, n, n_chunks + 1).astype(np.int64)
+        seqlets = []
+        with ThreadPoolExecutor(max_workers=n_chunks) as pool:
+            futures = [
+                pool.submit(
+                    _recursive_seqlets_decode,
+                    X=X[boundaries[c] : boundaries[c + 1]],
+                    rcdfs=rcdfs,
+                    global_xmin=global_xmin,
+                    bin_width=bin_width,
+                    threshold=threshold,
+                    min_seqlet_len=min_seqlet_len,
+                    max_seqlet_len=max_seqlet_len,
+                    additional_flanks=additional_flanks,
+                    row_offset=int(boundaries[c]),
+                )
+                for c in range(n_chunks)
+            ]
+            for future in futures:
+                seqlets.extend(future.result())
 
     columns = ["example_idx", "start", "end", "attribution", "p-value"]
     seqlets = pd.DataFrame(seqlets, columns=columns)
@@ -1767,18 +1773,14 @@ def recursive_seqlets(
 # cache=True writes the compiled kernel to __pycache__, so only the first run of a fresh
 # install pays the ~2s JIT compile instead of every process.
 @numba.njit(cache=True)
-def _recursive_seqlets_distribution(X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, n_bins=1000):
-    """Build the shared null-distribution model and per-example cumulative sums.
+def _recursive_seqlets_distribution(X, max_seqlet_len=25, n_bins=1000):
+    """Build the shared null-distribution model.
 
-    This is steps 1-3 of the recursive seqlet algorithm: bin attributions into a
-    histogram, derive per-length null distributions (1-CDFs), and compute each
-    example's cumulative attribution sum. These steps continually increment one
-    shared array and are not parallelized; step 4 (`_recursive_seqlets_decode`)
-    consumes their read-only output independently per example.
+    This is steps 1-2 of the recursive seqlet algorithm: bin attributions into a
+    histogram and derive per-length null distributions (1-CDFs).
 
     (1) Convert attribution scores into integer bins and calculate a histogram
     (2) Convert these histograms into null distributions across lengths
-    (3) Calculate each example's cumulative attribution sum
     """
     n, l = X.shape
     m = n * l
@@ -1817,49 +1819,49 @@ def _recursive_seqlets_distribution(X, threshold=0.01, min_seqlet_len=4, max_seq
         for i in range(1, n_bins * seqlet_len):
             rcdfs[seqlet_len, i] = max(rcdfs[seqlet_len, i - 1] - scores[seqlet_len, i], 0)
 
-    ###
-    # Step 3: Calculate cumulative attribution sums
-    ###
-
-    X_csum = np.zeros((n, l + 1))
-    for i in range(n):
-        for j in range(l):
-            X_csum[i, j + 1] = X_csum[i, j] + X[i, j]
-
-    return X_csum, rcdfs, xmin, bin_width
+    return rcdfs, xmin, bin_width
 
 
 @numba.njit(cache=True, nogil=True)
 def _recursive_seqlets_decode(
-    X_csum, rcdfs, xmin, bin_width, threshold, min_seqlet_len, max_seqlet_len, additional_flanks, row_offset
+    X, rcdfs, global_xmin, bin_width, threshold, min_seqlet_len, max_seqlet_len, additional_flanks, row_offset
 ):
-    """Decode seqlets for one contiguous block of examples (step 4).
+    """Compute cumulative attribution sums and decode seqlets for one contiguous block of examples (steps 3-4).
 
-    `X_csum` holds only the rows for this block; `row_offset` is added back so
+    `X` holds only the rows for this block; `row_offset` is added back so
     `example_idx` in the returned tuples matches the caller's global row index.
-    Independent per example, so this is safe to call concurrently from multiple
-    threads over disjoint row ranges of the same `X_csum`/`rcdfs` -- both are
-    read-only from this point on. Compiled with `nogil=True` so a
-    ThreadPoolExecutor calling this from several threads gets real multi-core
-    execution instead of contending for the GIL.
+
+    (3) Use the null distributions to calculate p-values based on the sequence's heights for each possible length
+    (4) Decode this matrix of p-values to find the longest seqlet
     """
-    n, lp1 = X_csum.shape
-    l = lp1 - 1
+    n, l = X.shape
 
     seqlets = []
 
     for i in range(n):
+        ###
+        # Step 3: Calculate p-values given these 1-CDFs
+        ###
+        # Calculate cumulative sums for this sequence specifically
+        X_csum = np.zeros(l + 1)
+        for j in range(l):
+            X_csum[j + 1] = X_csum[j] + X[i, j]
+
+        # Get p-values by comparing this sequence's cumulative seqs with the overall distribution
         p_value = np.ones((max_seqlet_len + 1, l), dtype=np.float64)
         p_value[:min_seqlet_len] = 0
         p_value[:, -min_seqlet_len] = 1
 
         for seqlet_len in range(min_seqlet_len, max_seqlet_len + 1):
             for k in range(l - seqlet_len + 1):
-                x_ = X_csum[i, k + seqlet_len] - X_csum[i, k]
-                x_ = math.floor((x_ - xmin * seqlet_len) / bin_width)
+                x_ = X_csum[k + seqlet_len] - X_csum[k]
+                x_ = math.floor((x_ - global_xmin * seqlet_len) / bin_width)
 
                 p_value[seqlet_len, k] = max(rcdfs[seqlet_len, x_], p_value[seqlet_len - 1, k])
 
+        ###
+        # Step 4: Decode p-values into seqlets
+        ###
         # Iteratively identify spans, from longest to shortest, that satisfy the
         # recursive p-value threshold.
         for j in range(max_seqlet_len - min_seqlet_len + 1):
@@ -1883,7 +1885,7 @@ def _recursive_seqlets_decode(
 
                     end = min(start + seqlet_len + additional_flanks, l - 1)
                     start = max(start - additional_flanks, 0)
-                    attr = X_csum[i, end] - X_csum[i, start]
+                    attr = X_csum[end] - X_csum[start]
                     seqlets.append((i + row_offset, start, end, attr, p))
 
     return seqlets

--- a/src/tfmindi/pp/seqlets.py
+++ b/src/tfmindi/pp/seqlets.py
@@ -1817,11 +1817,14 @@ def _recursive_seqlets_distribution(X, max_seqlet_len, n_bins):
 
     for seqlet_len in range(2, max_seqlet_len + 1):
         for i in range(n_bins * (seqlet_len - 1)):
+            prev_score = scores[seqlet_len - 1, i]
             for j in range(n_bins):
-                scores[seqlet_len, i + j] += scores[seqlet_len - 1, i] * f[j]
+                scores[seqlet_len, i + j] += prev_score * f[j]
 
+        current_rcdf = 1.0
         for i in range(1, n_bins * seqlet_len):
-            rcdfs[seqlet_len, i] = max(rcdfs[seqlet_len, i - 1] - scores[seqlet_len, i], 0)
+            current_rcdf = max(current_rcdf - scores[seqlet_len, i], 0)
+            rcdfs[seqlet_len, i] = current_rcdf
 
     return rcdfs, xmin, bin_width
 
@@ -1848,8 +1851,10 @@ def _recursive_seqlets_decode(
         ###
         # Calculate cumulative sums for this sequence specifically
         X_csum = np.zeros(l + 1)
+        current_csum = 0.0
         for j in range(l):
-            X_csum[j + 1] = X_csum[j] + X[i, j]
+            current_csum += X[i, j]
+            X_csum[j + 1] = current_csum
 
         # Get p-values by comparing this sequence's cumulative seqs with the overall distribution
         p_value = np.ones((max_seqlet_len + 1, l), dtype=np.float64)

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -13,7 +13,7 @@ from scipy import sparse
 from scipy.sparse import csr_array
 
 import tfmindi as tm
-from tfmindi.pp.seqlets import _prepare_motifs_for_finemo, finemo_fit_contrib
+from tfmindi.pp.seqlets import _prepare_motifs_for_finemo, finemo_fit_contrib, recursive_seqlets
 
 
 def _make_sparse_similarity_matrix(dense_matrix):
@@ -48,6 +48,15 @@ def _embed_motif(consensus, n=3, length=100, insert_pos=40, seed=0):
         for j, base in enumerate(consensus):
             contrib[i, base, insert_pos + j] = 2.0
     return contrib, oh, motif_len
+
+
+def _make_recursive_seqlets_input(n=6, length=60, seed=0):
+    """Synthetic 1D attribution tracks with strong spans, for calling recursive_seqlets directly."""
+    rng = np.random.default_rng(seed)
+    X = rng.normal(scale=0.05, size=(n, length))
+    X[:, 10:16] += 2.0
+    X[:, 30:38] += 2.0
+    return X
 
 
 class TestExtractSeqlets:
@@ -116,6 +125,42 @@ class TestExtractSeqlets:
         """method='finemo_fit_contrib' without `motifs` raises a clear ValueError."""
         with pytest.raises(ValueError, match="requires `motifs`"):
             tm.pp.extract_seqlets(sample_contrib_data, sample_oh_data, method="finemo_fit_contrib")
+
+
+class TestRecursiveSeqletsParallel:
+    """Test that recursive_seqlets' n_jobs parallelization doesn't change the result."""
+
+    @staticmethod
+    def _sorted_coords(seqlet_df):
+        cols = ["example_idx", "start", "end", "attribution"]
+        return seqlet_df[cols].sort_values(cols).reset_index(drop=True)
+
+    def test_n_jobs_matches_serial(self):
+        """Decoding across several threads finds the same seqlets as a single thread."""
+        X = _make_recursive_seqlets_input(n=8, length=60)
+        serial = recursive_seqlets(X, threshold=0.05, n_jobs=1)
+        parallel = recursive_seqlets(X, threshold=0.05, n_jobs=4)
+
+        assert len(serial) > 0
+        pd.testing.assert_frame_equal(self._sorted_coords(serial), self._sorted_coords(parallel))
+
+    def test_n_jobs_exceeds_example_count(self):
+        """n_jobs larger than the number of examples clamps to one chunk per example."""
+        X = _make_recursive_seqlets_input(n=3, length=60)
+        serial = recursive_seqlets(X, threshold=0.05, n_jobs=1)
+        parallel = recursive_seqlets(X, threshold=0.05, n_jobs=8)
+
+        pd.testing.assert_frame_equal(self._sorted_coords(serial), self._sorted_coords(parallel))
+        assert serial["example_idx"].max() == 2
+
+    @pytest.mark.parametrize("n_jobs", [1, 4])
+    def test_single_example(self, n_jobs):
+        """A single-example input works whether or not n_jobs exceeds the example count."""
+        X = _make_recursive_seqlets_input(n=1, length=60)
+        seqlets = recursive_seqlets(X, threshold=0.05, n_jobs=n_jobs)
+
+        assert len(seqlets) > 0
+        assert (seqlets["example_idx"] == 0).all()
 
 
 class TestPrepareMotifsForFinemo:


### PR DESCRIPTION
Was looking at the recursive_seqlets algo and realised there's a quick win in parallelizing the seqlet decoding (steps 3/4) once we've calculated the global distribution (steps 1/2). Steps 3/4 are independent for every sequence, while the global distribution is calculated from all sequences, so that's probably harder to parallelize? Seems race-condition-prone.

Code adjustments generated using Claude, which also tested it, yadda yadda. Every change checked for validity by me, and annoying Claude-style comments removed. On my local macbook, a 2.5x speedup with 8 cores. I think that's underselling it since that was presumably on a small test dataset, where the time taken this function doesn't dominate the seqlet calling, like it can with bigger datasets.
```
Synthetic benchmark, 4000 examples × 400 positions, 8 cores available, 3 runs each (JIT-warmed, excluded from timing):
┌─────────────────────────────────┬─────────┬───────────────────────┐
│             Version             │  Time   │      vs baseline      │
├─────────────────────────────────┼─────────┼───────────────────────┤
│ v2.0.0rc1 (pre-parallelization) │ ~0.397s │ —                     │
├─────────────────────────────────┼─────────┼───────────────────────┤
│ current, n_jobs=1               │ ~0.395s │ ~1.0x (no regression) │
├─────────────────────────────────┼─────────┼───────────────────────┤
│ current, n_jobs=-1 (8 threads)  │ ~0.159s │ ~2.5x faster          │
└─────────────────────────────────┴─────────┴───────────────────────┘
```

I ran it manually on the BICCN dataset on cata core CPUs, where 30 threads gives an even bigger speedup, and we get the exact same number of seqlets called on real data:
```
BICCN data from tutorial, full pp.extract_seqlets run: (first run excluded to ensure JIT compilation)
v2.0.0rc1 (pre-parallelization): 116.320s (seqlets found: 582915)
current, n_jobs=1: ~115.92s (115.931, 115.862, 115.960) (seqlets found: 582915)  
current, n_jobs=-1 (30 threads): ~15.41s (15.499, 15.586, 15.138) (seqlets found: 582915)  
```
So on 30 cores with a real dataset, ~7.5x speedup and same # of seqlets found.