### PR TITLE
Fix CDF construction in recursive_seqlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,18 @@ similarity matrices are bit-identical to previous versions and the reference pro
 
 ### Bugfixes
 
+- The recursive seqlet caller's null distributions had a hard p-value floor. `_recursive_seqlets_distribution`
+  built its reverse CDF as `rcdf[L, i] = rcdf[L, i-1] - scores[L, i]`, subtracting bin `i` at step `i`
+  instead of bin `i-1`, so `scores[L, 0]` was never removed from the tail. Every `rcdf[L, ...]` therefore
+  converged to `f[0]**L` instead of 0, and since the recursion takes the max over sub-spans, **no seqlet
+  could ever score below `f[0]**min_seqlet_len`**. On small datasets `f[0]` is negligible, but the
+  histogram's bin width is `(max - min) / (n_bins - 1)` over the *whole* dataset, so the larger the run
+  the more extreme its single global maximum and the more of the track collapses into bin 0. At
+  `f[0] = 0.74` the floor is 0.29 — which is why large runs appeared to need absurdly lenient thresholds
+  and then flipped from zero seqlets to everything within 0.001 of that value. Raising `n_bins` only
+  shrank `f[0]`; the floor is now gone at any `n_bins`. Inherited from the tangermeme implementation this
+  code was ported from. Seqlet calls change on all data (261 vs 262 and 228 vs 227 on the test fixtures).
+
 - `pl.pattern_logos` sizes its canvas from the subplot grid instead of a fixed 8x8 figure, so the
   two-line panel titles no longer overlap the logos and matplotlib no longer warns that tight layout
   could not be applied. Pass `width`/`height` to override.

--- a/src/tfmindi/pp/seqlets.py
+++ b/src/tfmindi/pp/seqlets.py
@@ -203,7 +203,7 @@ class rec_q99_smooth_abs(_1DSeqletCaller):  # noqa: D101
         min_seqlet_len: int = 4,
         max_seqlet_len: int = 25,
         additional_flanks: int = 3,
-        n_bins: int = 10000,
+        n_bins: int = 1000,
         n_jobs: int = -1,
     ) -> pd.DataFrame:
         """Core backbone: triangular smooth -> q99 normalise -> recursive abs caller."""
@@ -236,7 +236,7 @@ class recursive_raw(_1DSeqletCaller):  # noqa: D101
         min_seqlet_len: int = 4,
         max_seqlet_len: int = 25,
         additional_flanks: int = 3,
-        n_bins: int = 10000,
+        n_bins: int = 1000,
         n_jobs: int = -1,
     ) -> pd.DataFrame:
         """Baseline caller: recursive seqlets on the raw *signed* 1D track.
@@ -1133,7 +1133,8 @@ def extract_seqlets(
         - ``"recursive_q99_abs_smooth"`` (default): triangular-smooth, per-example
           q99 normalisation, then the recursive caller on ``abs(track)``.
           Accepts ``smooth_window`` (9), ``threshold`` (0.05), ``min_seqlet_len`` (4),
-          ``max_seqlet_len`` (25), ``additional_flanks`` (3), ``n_bins`` (10000).
+          ``max_seqlet_len`` (25), ``additional_flanks`` (3), ``n_bins`` (1000).
+          If calling seqlets on data with a large dynamic range, consider increasing `n_bins`.
         - ``"recursive_raw"``: recursive caller on the raw signed track
           (reproduces the previous TF-MInDi default behaviour). Same knobs as above.
         - ``"hysteresis"``: two-threshold local caller. Accepts ``smooth_window``,
@@ -1640,7 +1641,7 @@ def create_seqlet_adata(
 
 
 def recursive_seqlets(
-    X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, additional_flanks=0, n_bins=10000, n_jobs=-1
+    X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, additional_flanks=0, n_bins=1000, n_jobs=-1
 ):
     """Call seqlets using the recursive seqlet algorithm.
 
@@ -1714,7 +1715,7 @@ def recursive_seqlets(
             of all called seqlets. Does not affect the called seqlets.
     n_bins: int, optional
         The number of bins to use when estimating the PDFs and CDFs. Default is
-        10000.
+        1000.
     n_jobs: int, optional
         Number of threads to decode seqlets (steps 3 and 4) with. -1 (default) uses
         ``numba.get_num_threads()``.

--- a/src/tfmindi/pp/seqlets.py
+++ b/src/tfmindi/pp/seqlets.py
@@ -1820,9 +1820,14 @@ def _recursive_seqlets_distribution(X, max_seqlet_len, n_bins):
             for j in range(n_bins):
                 scores[seqlet_len, i + j] += prev_score * f[j]
 
+        # rcdfs[L, i] is the survival function P(score_bin >= i), so bin i-1 is the one
+        # leaving the tail at step i. Subtracting scores[L, i] instead (as tangermeme does)
+        # never removes scores[L, 0] = f[0]**L, leaving every p-value with a hard floor of
+        # f[0]**min_seqlet_len -- which becomes ~1 on large datasets, where a single extreme
+        # maximum sets bin_width and dumps most positions into bin 0.
         current_rcdf = 1.0
         for i in range(1, n_bins * seqlet_len):
-            current_rcdf = max(current_rcdf - scores[seqlet_len, i], 0)
+            current_rcdf = max(current_rcdf - scores[seqlet_len, i - 1], 0)
             rcdfs[seqlet_len, i] = current_rcdf
 
     return rcdfs, xmin, bin_width

--- a/src/tfmindi/pp/seqlets.py
+++ b/src/tfmindi/pp/seqlets.py
@@ -203,7 +203,7 @@ class rec_q99_smooth_abs(_1DSeqletCaller):  # noqa: D101
         min_seqlet_len: int = 4,
         max_seqlet_len: int = 25,
         additional_flanks: int = 3,
-        n_bins: int = 1000,
+        n_bins: int = 10000,
         n_jobs: int = -1,
     ) -> pd.DataFrame:
         """Core backbone: triangular smooth -> q99 normalise -> recursive abs caller."""
@@ -236,7 +236,7 @@ class recursive_raw(_1DSeqletCaller):  # noqa: D101
         min_seqlet_len: int = 4,
         max_seqlet_len: int = 25,
         additional_flanks: int = 3,
-        n_bins: int = 1000,
+        n_bins: int = 10000,
         n_jobs: int = -1,
     ) -> pd.DataFrame:
         """Baseline caller: recursive seqlets on the raw *signed* 1D track.
@@ -1133,8 +1133,7 @@ def extract_seqlets(
         - ``"recursive_q99_abs_smooth"`` (default): triangular-smooth, per-example
           q99 normalisation, then the recursive caller on ``abs(track)``.
           Accepts ``smooth_window`` (9), ``threshold`` (0.05), ``min_seqlet_len`` (4),
-          ``max_seqlet_len`` (25), ``additional_flanks`` (3), ``n_bins`` (1000).
-          If not calling any seqlets with very large datasets, consider increasing ``n_bins``.
+          ``max_seqlet_len`` (25), ``additional_flanks`` (3), ``n_bins`` (10000).
         - ``"recursive_raw"``: recursive caller on the raw signed track
           (reproduces the previous TF-MInDi default behaviour). Same knobs as above.
         - ``"hysteresis"``: two-threshold local caller. Accepts ``smooth_window``,
@@ -1641,7 +1640,7 @@ def create_seqlet_adata(
 
 
 def recursive_seqlets(
-    X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, additional_flanks=0, n_bins=1000, n_jobs=-1
+    X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, additional_flanks=0, n_bins=10000, n_jobs=-1
 ):
     """Call seqlets using the recursive seqlet algorithm.
 
@@ -1715,7 +1714,7 @@ def recursive_seqlets(
             of all called seqlets. Does not affect the called seqlets.
     n_bins: int, optional
         The number of bins to use when estimating the PDFs and CDFs. Default is
-        1000. Recommended to increase 5x or 10x when using large datasets.
+        10000.
     n_jobs: int, optional
         Number of threads to decode seqlets (steps 3 and 4) with. -1 (default) uses
         ``numba.get_num_threads()``.

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -67,7 +67,7 @@ class TestExtractSeqlets:
         seqlet_df, seqlet_matrices = tm.pp.extract_seqlets(sample_contrib_data, sample_oh_data)
 
         # Default method is recursive_q99_abs_smooth.
-        assert len(seqlet_df) == len(seqlet_matrices) == 262
+        assert len(seqlet_df) == len(seqlet_matrices) == 261
 
         assert isinstance(seqlet_df, pd.DataFrame)
         assert isinstance(seqlet_matrices, list)
@@ -83,7 +83,7 @@ class TestExtractSeqlets:
     def test_extract_seqlets_recursive_raw_reproduces_default(self, sample_contrib_data, sample_oh_data):
         """method='recursive_raw' reproduces the pre-change recursive-on-raw-track behaviour."""
         seqlet_df, seqlet_matrices = tm.pp.extract_seqlets(sample_contrib_data, sample_oh_data, method="recursive_raw")
-        assert len(seqlet_df) == len(seqlet_matrices) == 227
+        assert len(seqlet_df) == len(seqlet_matrices) == 228
 
     @pytest.mark.parametrize(
         "method",
@@ -538,9 +538,6 @@ class TestCreateSeqletAdata:
             }
         )
 
-        # Create seqlet matrices (4 x length for each seqlet)
-        seqlet_matrices = [np.random.rand(4, 15) for _ in range(n_seqlets)]
-
         # Create oh sequences and contrib scores (examples x 4 x total_length)
         oh_sequences = np.random.randint(0, 2, size=(3, 4, 100)).astype(float)
         contrib_scores = np.random.randn(3, 4, 100)
@@ -747,7 +744,6 @@ class TestCreateSeqletAdata:
         """Test behavior with empty inputs."""
         similarity_matrix = csr_array(np.array([]).reshape(0, 0))
         seqlet_metadata = pd.DataFrame()
-        seqlet_matrices = []
         oh_sequences = np.array([]).reshape(0, 4, 0)
         contrib_scores = np.array([]).reshape(0, 4, 0)
 
@@ -767,7 +763,6 @@ class TestCreateSeqletAdata:
         """Test error handling for dimension mismatches."""
         similarity_matrix = csr_array(np.random.rand(5, 3))
         seqlet_metadata = pd.DataFrame({"example_idx": [0, 1, 2]})  # Only 3 rows instead of 5
-        seqlet_matrices = [np.random.rand(4, 10) for _ in range(3)]  # Only 3 matrices instead of 5
 
         with pytest.raises(ValueError, match="Number of seqlets in similarity matrix"):
             tm.pp.create_seqlet_adata(similarity_matrix, seqlet_metadata)
@@ -791,11 +786,6 @@ class TestCreateSeqletAdata:
         seqlet_metadata = pd.DataFrame(
             {"example_idx": [0, 1, 0, 1, 2], "start": [10, 20, 30, 40, 50], "end": [25, 35, 45, 55, 65]}
         )
-
-        seqlet_matrices = [
-            np.array([[1.0, 0.5], [1e-7, 2.5], [100.0, 0.001], [0.999, np.pi]], dtype=np.float64)
-            for _ in range(n_seqlets)
-        ]
 
         oh_sequences = np.array(
             [
@@ -890,7 +880,6 @@ class TestCreateSeqletAdata:
             }
         )
 
-        seqlet_matrices = [np.random.rand(4, 12).astype(np.float64) for _ in range(n_seqlets)]
         oh_sequences = np.random.randint(0, 2, size=(5, 4, 500)).astype(np.float64)  # 5 examples
         contrib_scores = np.random.rand(5, 4, 500).astype(np.float64)
         motif_collection = {


### PR DESCRIPTION
See discussion in #66. 

Summary: on large datasets (or at least on my elegans dataset, and @bramstuyven has seen similar things I believe?), recursive seqlet calling needs unexpectedly high thresholds to call anything. Our current hypothesis is that this is due to weird behaviour in the null distribution captured in `rcdfs`: 
(note that this is not an inverse CDF but a 1-CDF/survival curve, I mixed up terms)
```
# Reproduce steps in the smoothed seqlet caller:
from tfmindi.pp.seqlets import _ensure_2d, _normalize_tracks, _triangular_smooth, _recursive_seqlets_distribution
smooth_window = 9
max_seqlet_len = 25
n_bins=1000
# Normalize the X
X = np.einsum("ncl,ncl->nl", contrib, oh)
X = _ensure_2d(X)
Xs = np.array([_triangular_smooth(x, smooth_window) for x in X], dtype=np.float64)
Xn = _normalize_tracks(Xs, mode="q99")
Xn = np.abs(Xn)
# Get distribution
rcdfs, global_xmin, bin_width = _recursive_seqlets_distribution(X=Xn, max_seqlet_len=max_seqlet_len, n_bins=n_bins)
# Plot distribution
fig, ax = plt.subplots()
ax.scatter(x = np.arange(rcdfs[7].shape[0]), y = rcdfs[7], s=1)
ax.set_title("1-CDF for seq-len 7 and n_bins 1000")
ax.set_ylabel('Frequency')
ax.set_xlabel("Normalized score (sum of 7-mer)")
```
<img width="567" height="454" alt="image" src="https://github.com/user-attachments/assets/1c73b57a-e57e-42fe-ac09-f2c26a677334" />

This distribution is supposed to reflect the overall distribution of normalized score sums of 7 adjacent stretches of nucleotides (kinda, it's a CDF-like, need to validate how exactly it's treated). Every nucleotide is normalized on a range from 0 to `n_bins`, so a theoretical case of 7 ties of the highest-scoring nucleotide in the entire dataset in a row would land at 7000; everything after that can never be reached and correctly is frequency 0 by default. Since most of the dataset is score 0, we expect 0 to be highly inflated and a quick dropoff afterwards. However, it should drop off to almost-0, not to 0.15 or whatever. If you view this as a 1-CDF, the CDF should approach the max (1 in normal CDF, 0 here) much more quickly, and should definitely reach it by the end; in the current implementation, it does not (which breaks the assumptions of a CDF). 

Anyway, increasing `n_bins` from 1000 to 10000 did result in better-looking distributions:
<img width="571" height="454" alt="image" src="https://github.com/user-attachments/assets/79daec67-2ddf-4670-9224-9c738f1511b3" />

Notably, it also finally allowed me to call seqlets with normal thresholds like 0.01 or 0.05, which previously would always return 0 seqlets. I previously had to go to threshold 0.295 to get any seqlets at all, which would immediately call a ton of them. 
Effects with `threshold=0.05` on one example region:
```
100 bins: found 0 seqlets in region 0
1000 bins: found 0 seqlets in region 0
5000 bins: found 98 seqlets in region 0
10000 bins: found 98 seqlets in region 0
```

However, increasing `n_bins` on datasets that previously seemed to work fine does have an effect: running the default tutorial increased seqlets found from 582915 with `n_bins=1000` to 684552 with `n_bins=10000`. 

To be explored:
- What's the effect on well-called datasets when you increase `n_bins`?
- Why are the CDFs breaking, and can we revert to lower values for `n_bins` if we figure that out?

